### PR TITLE
localProxyHost requires an additional dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ To use local proxy in local testing -
 * localProxyPass: Password for USERNAME, will be ignored if USERNAME is empty or not specified
 
 ```java
-bsLocalArgs.put("localProxyHost", "127.0.0.1");
-bsLocalArgs.put("localProxyPort", "8000");
+bsLocalArgs.put("-localProxyHost", "127.0.0.1");
+bsLocalArgs.put("-localProxyPort", "8000");
 bsLocalArgs.put("-localProxyUser", "user");
 bsLocalArgs.put("-localProxyPass", "password");
 ```


### PR DESCRIPTION
We add some syntactic sugar for `proxyHost`, Local will automatically add a dash a that beginning of the parameter name. 
see link: https://github.com/browserstack/browserstack-local-java/blob/3ffdab3366fa24e6d0809da5093b200cf7be8794/src/main/java/com/browserstack/local/Local.java#L42
But don't have the same behavior with localProxyHost. So we must use `-localProxyHost` instead.

Same for localProxyPort