### PR TITLE
[LOC-5083] Add support for Linux arm64 binary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.browserstack</groupId>
     <artifactId>browserstack-local-java</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.7</version>
+    <version>1.1.8</version>
 
     <name>browserstack-local-java</name>
     <description>Java bindings for BrowserStack Local</description>

--- a/src/main/java/com/browserstack/local/Local.java
+++ b/src/main/java/com/browserstack/local/Local.java
@@ -23,7 +23,7 @@ public class Local {
     private LocalProcess proc = null;
 
     // Current version of binding package, used for --source option of binary
-    private static final String packageVersion = "1.1.7";
+    private static final String packageVersion = "1.1.8";
     private final Map<String, String> parameters;
     private final Map<String, String> avoidValueParameters;
 

--- a/src/main/java/com/browserstack/local/LocalBinary.java
+++ b/src/main/java/com/browserstack/local/LocalBinary.java
@@ -79,7 +79,9 @@ class LocalBinary {
             binFileName = "BrowserStackLocal-darwin-x64";
         } else if (osname.contains("linux")) {
             String arch = System.getProperty("os.arch");
-            if (arch.contains("64")) {
+            if (arch.contains("aarch64")) {
+                binFileName = "BrowserStackLocal-linux-arm64";
+            } else if (arch.contains("64")) {
                 if (isAlpine()) {
                     binFileName = "BrowserStackLocal-alpine";
                 } else {


### PR DESCRIPTION
Detect aarch64 architecture (os.arch contains 'aarch64') before the generic 64-bit check so that arm64 systems download BrowserStackLocal-linux-arm64 instead of the x64 binary.